### PR TITLE
main uber-cache.js script is in ./lib/ not ./

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     { "type": "git"
     , "url": "git@github.com:serby/uber-cache"
     }
-, "main": "uber-cache.js"
+, "main": "./lib/uber-cache.js"
 , "scripts":
     { "test": "mocha -r should"
     }


### PR DESCRIPTION
Module is broken as `require('uber-cache')` doesn't actually point at a valid file.
