### PR TITLE
Add sigmund as the default arguments hasher for memoize

### DIFF
--- a/lib/uber-cache.js
+++ b/lib/uber-cache.js
@@ -1,11 +1,12 @@
 var _ = require('lodash')
   , semver = require('semver')
   , version = require('../package.json').version
+  , hash = require('sigmund')
 
-// This simple hasher is quick, but no good for object arguments.
-// If you need a more advanced you can pass as an option.
+// This hasher will descend 10 levels of object nesting in the arguments
+// of a memoized function. If you need a more advanced you can pass as an option.
 function hasher() {
-  return '_' + Array.prototype.slice.call(arguments).toString()
+  return hash(arguments, 10)
 }
 
 module.exports = function createUberCache(opts) {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "node": ">=0.10"
   },
   "dependencies": {
+    "async": "^0.2.10",
     "lodash": "^2.4.1",
     "lru-cache": "^2.5.0",
-    "async": "^0.2.10",
-    "semver": "^2.2.1"
+    "semver": "^2.2.1",
+    "sigmund": "^1.0.0"
   },
   "devDependencies": {
     "async": "^0.2.10",

--- a/test/uber-cache.test.js
+++ b/test/uber-cache.test.js
@@ -115,6 +115,56 @@ describe('uber-cache', function () {
 
     })
 
+    it('should cache a function call with an object as an argument', function (done) {
+
+      var alreadyCalled = false
+
+      function keys(object, cb) {
+        alreadyCalled.should.equal(false)
+        alreadyCalled = true
+        cb(null, Object.keys(object))
+      }
+
+      var cache = createUberCache()
+        , fn = cache.memoize('test5', keys, 1000)
+
+      fn({ a: 1, b: 2, c: 3 }, function (err, keys) {
+        should.not.exist(err)
+        keys.should.eql([ 'a', 'b', 'c' ])
+        fn({ a: 1, b: 2, c: 3 }, function (err, keys) {
+          should.not.exist(err)
+          keys.should.eql([ 'a', 'b', 'c' ])
+          done()
+        })
+      })
+
+    })
+
+    it('should not cache a function call with different objects as arguments', function (done) {
+
+      var times = 0
+
+      function keys(object, cb) {
+        times++
+        cb(null, Object.keys(object))
+      }
+
+      var cache = createUberCache()
+        , fn = cache.memoize('test5', keys, 1000)
+
+      fn({ a: 1, b: 2, c: 3 }, function (err, keys) {
+        should.not.exist(err)
+        keys.should.eql([ 'a', 'b', 'c' ])
+        fn({ a: 3, b: 2, c: 1 }, function (err, keys) {
+          should.not.exist(err)
+          keys.should.eql([ 'a', 'b', 'c' ])
+          times.should.equal(2)
+          done()
+        })
+      })
+
+    })
+
   })
 
 })


### PR DESCRIPTION
This is the most common use case for all of our applications,
so it makes sense to set it as the default. You can still
pass in a custom hasher as an option.

Added two tests to ensure that function calls with matching
objects are cached, and calls with different objects are not.
