### PR TITLE
Updating readme to show ttl parameter is milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ necessary to use a callback style when manipulating the cache.
 
 ```js
 
-var ttlInSeconds = 1
+var ttlInMilliseconds = 1
   , someData = { some: 'data' }
 
-cache.set('some-key', someData, ttlInSeconds, function(error, cachedItem) {
+cache.set('some-key', someData, ttlInMilliseconds, function(error, cachedItem) {
   if (error) {
     // Handle the error
     return false


### PR DESCRIPTION
TTL is readme code example is shown as seconds, when docs show it as milliseconds.